### PR TITLE
bugfix disable advancedFraudSignals url

### DIFF
--- a/src/load-stripe-sdk.js
+++ b/src/load-stripe-sdk.js
@@ -6,7 +6,7 @@ export const loadStripeSdk = ({ version = 'v3', disableAdvancedFraudDetection },
     return;
   }
   let url = `${STRIPE_JS_SDK_URL}/${version}`;
-  if (disableAdvancedFraudDetection) url += `${url}?advancedFraudSignals=false`;
+  if (disableAdvancedFraudDetection) url += `?advancedFraudSignals=false`;
   const e = document.createElement('script');
   e.src = url;
   e.type = 'text/javascript';


### PR DESCRIPTION
The URL generated was incorrect (https://js.stripe.com/v3https://js.stripe.com/v3?advancedFraudSignals=false) and resulted in a 404 when loading stripe-js when disableAdvancedFraudDetection = true.