### PR TITLE
Properly hide submit button

### DIFF
--- a/src/elements/Card.vue
+++ b/src/elements/Card.vue
@@ -268,6 +268,6 @@ export default {
 }
 
 .hide {
-  visibility: hidden;
+  display: none;
 }
 </style>


### PR DESCRIPTION
`visibility: hidden` still renders a space in some browsers.
`display: none` does not.