### PR TITLE
Add type for StripePaymentToken, add submit function to StripeElementCard class

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -60,3 +60,45 @@ export class StripeElementCard extends Vue {
 
   submit(): void;
 }
+
+export interface StripePaymentToken {
+  client_ip: string;
+  created: number;
+  id: string;
+  livemode: boolean;
+  object: string;
+  type: StripeTokenType;
+  used: boolean;
+  card?: StripeCard;
+  back_account?: StripeBankAccount;
+}
+
+export interface StripeCard {
+  address_city: string | null;
+  address_country: string | null;
+  address_line1: string | null;
+  address_line1_check: StripeAddressLineCheck;
+  address_line2: string | null;
+  address_state: string | null;
+  address_zip: string;
+  address_zip_check: StripeAddressCheck;
+  brand: StripeCardBrand;
+  country: string;
+  cvc_check: StripeAddressCheck;
+  dynamic_last4: string | null;
+  exp_month: number;
+  exp_year: number;
+  funding: StripeCardFundingType;
+  id: string;
+  last4: string;
+  name: string | null;
+  object: string;
+  tokenization_method: StripeTokenizationMethod;
+}
+
+export type StripeAccountHolder = 'individual' | 'company';
+export type StripeCardBrand = 'American Express' | 'Diners Club' | 'Discover' | 'JCB' | 'MasterCard' | 'UnionPay' | 'Visa' | 'Unknown';
+export type StripeCardFundingType = 'credit' | 'debit' | 'prepaid' | 'unknown';
+export type StripeTokenizationMethod = 'android_pay' | 'apple_pay' | 'masterpass' | 'visa_checkout' | null;
+export type StripeAddressCheck = 'pass' | 'fail' | 'unchecked' | 'unavailable' | null;
+export type StripeTokenType = 'account' | 'bank_account' | 'card' | 'pii';

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -57,4 +57,6 @@ export class StripeElementCard extends Vue {
   elementStyle: any;
   value?: string;
   hidePostalCode: boolean;
+
+  submit(): void;
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -70,7 +70,6 @@ export interface StripePaymentToken {
   type: StripeTokenType;
   used: boolean;
   card?: StripeCard;
-  back_account?: StripeBankAccount;
 }
 
 export interface StripeCard {


### PR DESCRIPTION
- StripeElementCard contains `submit()` that was not reflected in the types declaration file.
   - Refer to: https://vuestripe.com/stripe-elements/card
   - `this.$refs.elementRef.submit();`
- StripePaymentToken response from Stripe Element types were not represented in the types declaration file.
   - Types were added to conform with https://stripe.com/docs/api/tokens/object
