### PR TITLE
Add tokenCreation Data to Card Element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-stripe/vue-stripe",
-  "version": "4.2.5",
+  "version": "4.2.6",
   "description": "Stripe Checkout & Elements for Vue.js",
   "author": "jofftiquez@gmail.com",
   "scripts": {

--- a/src/elements/Card.vue
+++ b/src/elements/Card.vue
@@ -48,6 +48,10 @@ export default {
       type: Object,
       default: () => ({}),
     },
+    tokenData: {
+      type: Object,
+      default: () => ({}),
+    },
     disableAdvancedFraudDetection: {
       type: Boolean,
     },
@@ -140,7 +144,7 @@ export default {
           ...this.element,
         };
         if (this.amount) data.amount = this.amount;
-        const { token, error } = await this.stripe.createToken(data);
+        const { token, error } = await this.stripe.createToken(data, this.tokenData);
         if (error) {
           const errorElement = document.getElementById('stripe-element-errors');
           errorElement.textContent = error.message;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -52,6 +52,7 @@ export class StripeElementCard extends Vue {
   apiVersion: string;
   locale: string;
   elementsOptions: any;
+  tokenData: any;
   disableAdvancedFraudDetection: boolean;
   classes: any;
   elementStyle: any;


### PR DESCRIPTION
Stripe docs highly recommend you pass in name and country:  https://stripe.com/docs/js/tokens_sources/create_token?type=cardElement

This allows the user to pass in that data, as well as any other data required for Radar

```html
    <v-text-field
            v-model="zip" <!-- do for each name address city state zip -->
            label="ZIP / Postal Code"
            placeholder="ZIP"
          ></v-text-field>

    <stripe-element-card
            ref="card"
            :pk="pk"
            @token="tokenCreated"
            :tokenData="{
              name: name,
              address_line1: address,
              address_city: city,
              address_state: state,
              address_zip: zip,
              address_country: 'US',
            }"
      />
```
