### PR TITLE
Non redirect confirm emit continued (Follow up on #288)

### DIFF
--- a/src/elements/Payment.vue
+++ b/src/elements/Payment.vue
@@ -144,7 +144,7 @@ export default {
           this.$emit('error', error);
           return;
 
-        } else if( paymentIntent ) {
+        } else if ( paymentIntent ) {
           // if the user has passed prop redirect="if_required"
           // and the payment confirmation was successful
           // and the payment method is not forced to redirect

--- a/src/elements/Payment.vue
+++ b/src/elements/Payment.vue
@@ -137,24 +137,22 @@ export default {
         });
 
         // if the response is an error
-        if ( error ) {
+        if (error) {
           const errorElement = document.getElementById(
             'stripe-payment-element-errors',
           );
           errorElement.textContent = error.message;
           this.$emit('error', error);
           return;
-
-        } else if ( paymentIntent ) {
+        } else if (paymentIntent) {
           // if the user has passed prop redirect="if_required"
           // and the payment confirmation was successful
           // and the payment method is not forced to redirect
           // then stripe.confirmPayment resolves with a paymentIntent
           // so we sould pass it back up to the caller for consumption
           // https://stripe.com/docs/js/payment_intents/confirm_payment?type=pii#confirm_payment_intent-options-redirect
-          this.$emit('confirmed', response.paymentIntent)
+          this.$emit('confirmed', paymentIntent);
         }
-
       } catch (error) {
         console.error(error);
         this.$emit('error', error);

--- a/src/elements/Payment.vue
+++ b/src/elements/Payment.vue
@@ -129,22 +129,22 @@ export default {
       try {
         this.$emit('loading', true);
         event.preventDefault();
-        const response = await this.stripe.confirmPayment({
+        const { error, paymentIntent } = await this.stripe.confirmPayment({
           elements: this.elements,
           confirmParams: this.confirmParams,
           redirect: this.redirect
         });
 
         // if the response is an error
-        if ( response.error ) {
+        if ( error ) {
           const errorElement = document.getElementById(
             'stripe-payment-element-errors',
           );
-          errorElement.textContent = response.error.message;
-          this.$emit('error', response.error);
+          errorElement.textContent = error.message;
+          this.$emit('error', error);
           return;
 
-        } else if( response.paymentIntent ) {
+        } else if( paymentIntent ) {
           // if the user has passed prop redirect="if_required"
           // and the payment confirmation was successful
           // and the payment method is not forced to redirect

--- a/src/elements/Payment.vue
+++ b/src/elements/Payment.vue
@@ -144,14 +144,14 @@ export default {
           this.$emit('error', response.error);
           return;
 
-        } else {
+        } else if( response.paymentIntent ) {
           // if the user has passed prop redirect="if_required"
           // and the payment confirmation was successful
           // and the payment method is not forced to redirect
           // then stripe.confirmPayment resolves with a paymentIntent
           // so we sould pass it back up to the caller for consumption
           // https://stripe.com/docs/js/payment_intents/confirm_payment?type=pii#confirm_payment_intent-options-redirect
-          this.$emit('confirmed', response)
+          this.$emit('confirmed', response.paymentIntent)
         }
 
       } catch (error) {


### PR DESCRIPTION
Follow up for #269 

Since PR #288  seems to be inactive, here are the requested changes. It would be very awesome if this PR could be merged, as I need this functionality for my current project.

Original PR content

```
Follow up for https://github.com/vue-stripe/vue-stripe/issues/269

Tested, works

If the user has passed prop redirect="if_required" and the payment confirmation was successful and the payment method is not forced to redirect then stripe.confirmPayment resolves with a paymentIntent so we sould pass it back up to the caller for consumption:
https://stripe.com/docs/js/payment_intents/confirm_payment?type=pii#confirm_payment_intent-options-redirect
```